### PR TITLE
Reference Link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "^18.2.0",
         "@angular/platform-browser-dynamic": "^18.2.0",
         "@angular/router": "^18.2.0",
-        "dompurify": "^3.2.0",
+        "dompurify": "^3.2.6",
         "ngx-quill": "^26.0.8",
         "quill": "^2.0.2",
         "quill-delta": "^5.1.0",
@@ -4527,6 +4527,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -7082,9 +7088,12 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-AMdOzK44oFWqHEi0wpOqix/fUNY707OmoeFDnbi3Q5I8uOpy21ufUA5cDJPr0bosxrflOVD/H2DMSvuGKJGfmQ=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^18.2.0",
     "@angular/platform-browser-dynamic": "^18.2.0",
     "@angular/router": "^18.2.0",
-    "dompurify": "^3.2.0",
+    "dompurify": "^3.2.6",
     "ngx-quill": "^26.0.8",
     "quill": "^2.0.2",
     "quill-delta": "^5.1.0",

--- a/src/app/_classes/reference-link.ts
+++ b/src/app/_classes/reference-link.ts
@@ -1,12 +1,18 @@
-import * as url from "node:url";
 
 export class ReferenceLink {
-  constructor(url: string, label: string, description: string, sectionId: string, icon: string) {
+  constructor(id: string, url: string, label: string, description: string, sectionId: string, icon: string) {
+    this._id = id;
     this._url = url;
     this._label = label;
     this._description = description;
     this._sectionId = sectionId;
     this._icon = icon;
+  }
+
+  private _id: string;
+
+  get id(): string{
+    return this.id;
   }
 
   /** Target URL (absolute or in‑app relative path). */

--- a/src/app/_classes/step.ts
+++ b/src/app/_classes/step.ts
@@ -8,6 +8,7 @@
 import {Condition} from "./condition";
 import {StepChoice} from "./step-choice";
 import {SanitizeService} from "../_services/sanitize.service";
+import { ReferenceLink } from "./reference-link";
 
 
 export class Step {
@@ -31,6 +32,11 @@ export class Step {
    * Determines a step is required to complete the decision support or not (0 - no, 1 -yes)
    */
   required: string;
+  /**
+   * An array of reference Link.
+   * Which has a label, url and description.
+   */
+  referenceLink: ReferenceLink[];
   /**
    * An array of step choices.
    * If an step has no choices, it will still be populated by one step choice. It's not used.
@@ -67,6 +73,7 @@ export class Step {
     type: string,
     required: string,
     description: string,
+    referenceLink: ReferenceLink[],
     choices: StepChoice[],
     conditions: Condition[],
     isCompleted: boolean,
@@ -80,6 +87,7 @@ export class Step {
     this.description = SanitizeService.sanitizeStatic(description);// Fallback to raw description if sanitizeService is not provided
     this.type = type;
     this.required = required;
+    this.referenceLink = referenceLink;
     this.choices = choices;
     this.conditions = conditions;
     this.isCompleted = isCompleted;

--- a/src/app/_components/decision-support/decision-support.component.html
+++ b/src/app/_components/decision-support/decision-support.component.html
@@ -12,7 +12,7 @@
       <div *ngFor="let step of decisionSupportDetails?.steps; let i = index">
         <div [ngClass]="{'disabled-step': !step.isVisible}">
           <!-- Clickable area going to step. -->
-          <a (click)="getStep(step.stepUuid)" [ngClass]="{'active-step': oneStep?.stepUuid === step.stepUuid}">
+          <a class="sidebar-a" (click)="getStep(step.stepUuid)" [ngClass]="{'active-step': oneStep?.stepUuid === step.stepUuid}">
             <!-- Round number display icon (goes green when step is completed) -->
             <span>
                 <ng-content select="[icon]">
@@ -54,9 +54,27 @@
         Submit
       </button>
     </div>
+    <!-------------------------------------------------------------------->
     <div *ngIf="oneStep">
-      <!-- Heading and description. -->
+
       <h2>Step {{ oneStep.id }} </h2>
+      <div class="link-container" *ngIf="oneStep.referenceLink">
+                    <div class="link-sub-container-1">
+                         <p><b>Supporting Links</b></p> 
+                    </div>
+
+                    <div class="link-sub-container-2">
+                        <div *ngFor="let referenceLink of oneStep?.referenceLink">
+                       
+                                <p>{{referenceLink.id}}<a class="reference-link-a" href="{{oneStep.url}}" title="{{referenceLink.description}}" target="_blank" rel="noopener noreferrer">
+                                    {{referenceLink.label}}
+                                </a></p>
+                           
+                            </div>
+                    </div>
+                </div>
+  <!-------------------------------------------------------------------->
+      <!-- Heading and description. -->
       <p>{{ oneStep.description }}</p>
 
       <!-- STEP TYPE: Radio and Text Box -->

--- a/src/app/_components/decision-support/decision-support.component.scss
+++ b/src/app/_components/decision-support/decision-support.component.scss
@@ -14,7 +14,7 @@
   color: black;
 }
 
-a {
+.sidebar-a {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -135,4 +135,33 @@ display: flex;
 justify-content: center;
 align-items: center;
 height: 70vh;
+}
+.link-container {
+  display: flex;
+  width: 100%;
+  border: 1px  #ccc; 
+  border-radius: 8px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
+  margin: 16px auto; 
+  overflow: hidden; 
+}
+
+.link-sub-container-1 {
+  width: 10%;
+  display: flex;
+  justify-content: center; 
+  align-items: center;     
+  background-color: #dfdfdd; 
+  overflow: hidden;
+  padding: 10px;
+}
+
+.link-sub-container-2 {
+  width:90%;
+  align-items: center; 
+  padding-left: 8px;
+}
+
+.reference-link-a{
+  text-decoration: none;
 }

--- a/src/app/_components/dialog-components/process-dialog/add-process-step-dialog/add-process-step-dialog.component.html
+++ b/src/app/_components/dialog-components/process-dialog/add-process-step-dialog/add-process-step-dialog.component.html
@@ -10,12 +10,14 @@
     <!-- Process Step Description -->
     <p>Description</p>
     <mat-form-field appearance="outline">
-      <input matInput [(ngModel)]="formData.description" name="description" placeholder="Description" (ngModelChange)="addDataToLocalStorage()" required>
+      <input matInput [(ngModel)]="formData.description" name="description" placeholder="Description"
+        (ngModelChange)="addDataToLocalStorage()" required>
     </mat-form-field>
     <!-- Process Step Required Status-->
     <p>Required</p>
     <mat-form-field appearance="outline">
-      <mat-select [(ngModel)]="formData.required" name="required" placeholder="Select Required Status" (ngModelChange)="addDataToLocalStorage()"  required>
+      <mat-select [(ngModel)]="formData.required" name="required" placeholder="Select Required Status"
+        (ngModelChange)="addDataToLocalStorage()" required>
         <mat-option [value]="'1'">Yes</mat-option>
         <mat-option [value]="'0'">No</mat-option>
       </mat-select>
@@ -23,17 +25,46 @@
     <!-- Process Step Type-->
     <p>Element Type</p>
     <mat-form-field appearance="outline">
-      <mat-select [(ngModel)]="formData.type" name="type" placeholder="Select Element Type" (ngModelChange)="addDataToLocalStorage()"  required>
+      <mat-select [(ngModel)]="formData.type" name="type" placeholder="Select Element Type"
+        (ngModelChange)="addDataToLocalStorage()" required>
         <mat-option *ngFor="let type of type" [value]="type.value">{{ type.label }}</mat-option>
       </mat-select>
     </mat-form-field>
 
+    <!---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
+    <!--Reference Link-->
+    <p>Reference Link</p>
+    <div *ngFor="let referenceLink of formData.referenceLink; let i = index">
+      <div class="link-header">
+      <p>Link {{i + 1}}</p>
+      <button mat-icon-button type="button"><mat-icon class="material-icons" (click)="removeReferenceLink(i)">delete</mat-icon></button>
+      </div>
+      <mat-form-field appearance="outline">
+         <mat-label>Label</mat-label>
+        <input matInput [(ngModel)]="referenceLink.label" name="referenceLabel{{i}}" (ngModelChange)="addDataToLocalStorage()" required>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+         <mat-label>Link</mat-label>
+        <input matInput [(ngModel)]="referenceLink.url" name="referenceLink{{i}}" (ngModelChange)="addDataToLocalStorage()" required>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+         <mat-label>Description</mat-label>
+       <input matInput [(ngModel)]="referenceLink.description" name="referenceDescription{{i}}"  (ngModelChange)="addDataToLocalStorage()" required>
+      </mat-form-field>
+      
+    </div>
+    <button class="add" mat-button type="button" (click)="addReferenceLink()">Add Refernce Link</button>
+
+<!---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
+
     <!-- Add/Remove Process Step Choices if the step type radio/checkbox -->
-    <div *ngIf="formData.type === 'radio' || formData.type === 'radio&text' || formData.type === 'checkbox&text' || formData.type === 'checkbox'">
+    <div
+      *ngIf="formData.type === 'radio' || formData.type === 'radio&text' || formData.type === 'checkbox&text' || formData.type === 'checkbox'">
       <p>Options:</p>
       <div *ngFor="let choice of formData.choices; let i = index">
         <mat-form-field appearance="outline">
-          <input matInput [(ngModel)]="choice.description" placeholder="Option {{ i + 1 }}"  name="choice{{i}}" (ngModelChange)="addDataToLocalStorage()" required>
+          <input matInput [(ngModel)]="choice.description" placeholder="Option {{ i + 1 }}" name="choice{{i}}"
+            (ngModelChange)="addDataToLocalStorage()" required>
           <!-- Remove Choice -->
           <button mat-icon-button type="button" (click)="removeChoice(i)">
             <mat-icon class="material-icons">delete</mat-icon>
@@ -49,15 +80,20 @@
       <!-- Condition Step description -->
       <mat-form-field appearance="outline">
         <p>Condition {{ i + 1 }}</p>
-        <mat-select [(ngModel)]="condition.stepUuid" name="conditionStep{{i}}" (selectionChange)="updateStepConditionChoices(condition.stepUuid, i)" placeholder="Select Step" (ngModelChange)="addDataToLocalStorage()"  required>
-          <mat-option *ngFor="let step of filteredStepsData" [value]="step.stepUuid">{{ step.id }}. {{ step.description }}</mat-option>
+        <mat-select [(ngModel)]="condition.stepUuid" name="conditionStep{{i}}"
+          (selectionChange)="updateStepConditionChoices(condition.stepUuid, i)" placeholder="Select Step"
+          (ngModelChange)="addDataToLocalStorage()" required>
+          <mat-option *ngFor="let step of filteredStepsData" [value]="step.stepUuid">{{ step.id }}. {{ step.description
+            }}</mat-option>
         </mat-select>
       </mat-form-field>
       <!-- Condition Step Value-->
       <mat-form-field appearance="outline">
         <p>Value is</p>
-        <mat-select [(ngModel)]="condition.choiceUuid" name="conditionChoice{{i}}" placeholder="Select Value" (ngModelChange)="addDataToLocalStorage()"  required>
-          <mat-option *ngFor="let choice of condition.stepChoices" [value]="choice.choiceUuid">{{ choice.description }}</mat-option>
+        <mat-select [(ngModel)]="condition.choiceUuid" name="conditionChoice{{i}}" placeholder="Select Value"
+          (ngModelChange)="addDataToLocalStorage()" required>
+          <mat-option *ngFor="let choice of condition.stepChoices" [value]="choice.choiceUuid">{{ choice.description
+            }}</mat-option>
         </mat-select>
         <!-- Remove Condition -->
         <button mat-icon-button type="button" (click)="removeCondition(i)">

--- a/src/app/_components/dialog-components/process-dialog/add-process-step-dialog/add-process-step-dialog.component.scss
+++ b/src/app/_components/dialog-components/process-dialog/add-process-step-dialog/add-process-step-dialog.component.scss
@@ -86,3 +86,8 @@ buton[enabled]{
   background-color: #7a9bbf;
   border-radius: 10px;
 }
+
+.link-header{
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/app/_components/dialog-components/process-dialog/add-process-step-dialog/add-process-step-dialog.component.ts
+++ b/src/app/_components/dialog-components/process-dialog/add-process-step-dialog/add-process-step-dialog.component.ts
@@ -32,6 +32,7 @@ export class AddProcessStepDialogComponent {
     description: '',
     required: '',
     type: '',
+    referenceLink: [],
     choices: [],
     conditions: []
   };
@@ -110,6 +111,20 @@ export class AddProcessStepDialogComponent {
     if (selectedStep && selectedStep.choices) {
       this.formData.conditions[conditionIndex].stepChoices = selectedStep.choices;
     }
+  }
+
+  /** Reference Link */
+    addReferenceLink(){
+    this.formData.referenceLink.push({
+      id: this.formData.referenceLink.length + 1,
+      label: '',
+      url:'',
+      description: ''
+    });
+  }
+
+  removeReferenceLink(index:number){
+    this.formData.referenceLink.splice(index, 1);
   }
 
   /** Close the dialog and reset form data when user clicks close button */

--- a/src/app/_components/preview-process-steps/preview-process-steps.component.html
+++ b/src/app/_components/preview-process-steps/preview-process-steps.component.html
@@ -2,15 +2,34 @@
   @component Preview Process Steps Component
   @description Display the preview of process step
 -->
-<div class="container" *ngIf= "response">
+<div class="container" *ngIf="response">
     <!-- The preview container to display the steps -->
-    <div class="preview-container" >
+    <div class="preview-container">
         <!-- Check is steps available -->
         <div *ngIf="processSteps.length != 0">
             <h1>{{processDetails.label}}</h1>
             <!-- Display steps based on type -->
             <div *ngFor="let processStep of processSteps">
                 <h2>Step {{processStep.id}} </h2>
+
+<!---------------------------------------------------------Reference Link--------------------------------------------------------------------------------------------------------------------------------->
+                <div class="link-container" *ngIf="processStep.referenceLink">
+                    <div class="link-sub-container-1">
+                       <p><b>Supporting Links</b></p> 
+                    </div>
+
+                    <div class="link-sub-container-2">
+                        <div *ngFor="let referenceLink of processStep?.referenceLink">
+                       
+                                <p>{{referenceLink.id}}<a href="{{referenceLink.url}}" title="{{referenceLink.description}}" target="_blank" rel="noopener noreferrer">
+                                    {{referenceLink.label}}
+                                </a></p>
+                           
+                            </div>
+                    </div>
+                </div>
+<!---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
+
                 <p>{{processStep.description}}</p>
                 <!-- Radio & Text Boxes -->
                 <div *ngIf="processStep.type === 'radio&text'">

--- a/src/app/_components/preview-process-steps/preview-process-steps.component.scss
+++ b/src/app/_components/preview-process-steps/preview-process-steps.component.scss
@@ -40,3 +40,34 @@ h1{
     align-items: center;
     height: 70vh;
   }
+
+.link-container {
+  display: flex;
+  width: 100%;
+  border: 1px  #ccc; 
+  border-radius: 8px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
+  margin: 16px auto; 
+  overflow: hidden; 
+}
+
+.link-sub-container-1 {
+  width: 10%;
+  display: flex;
+  justify-content: center; 
+  align-items: center;     
+ background-color: #dfdfdd; 
+  overflow: hidden;
+  padding: 10px;
+}
+
+.link-sub-container-2 {
+  width:90%;
+  align-items: center; 
+  padding-left: 8px;
+}
+
+
+a{
+  text-decoration: none;
+}


### PR DESCRIPTION
Updated the frontend to add and display supporting links for each step

## Summary by Sourcery

Enable users to attach and view supporting reference links for each process step by extending data models, adding controls in the add-step dialog, and rendering links with new styles in the preview and decision support views.

New Features:
- Allow adding multiple reference links (label, URL, and description) when creating a process step
- Display supporting reference links in both the process steps preview and decision support components

Enhancements:
- Extend Step and ReferenceLink classes to include referenceLink properties and identifiers
- Add add/remove handlers and bind reference link fields in the add-step dialog component
- Introduce SCSS styling for reference link containers and link elements across relevant components

Build:
- Bump dompurify dependency from ^3.2.0 to ^3.2.6